### PR TITLE
Fix routing wildcard example

### DIFF
--- a/en/development/routing.rst
+++ b/en/development/routing.rst
@@ -831,7 +831,7 @@ the ``*.`` wildcard to match any subdomain::
         $routes->connect(
             '/images/old-log.png',
             ['controller' => 'Images', 'action' => 'oldLogo']
-        )->setHost('images.example.com');
+        )->setHost('*.example.com');
     });
 
 The ``_host`` option is also used in URL generation. If your ``_host`` option


### PR DESCRIPTION
Wildcard was lost during 3.5 fluent route conversion